### PR TITLE
Zenn: LinkCard記法への対応。

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -38,6 +38,10 @@ pub enum Element {
     Text(String),
     Url(String),
     Macro(ParsedMacro),
+    LinkCard {
+        card_type: String,
+        url: String,
+    },
     Image {
         alt: String,
         url: String,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -109,6 +109,14 @@ impl QiitaCompiler {
             Element::Text(text) => text,
             Element::Url(url) => format!("\n{}\n", url),
             Element::Macro(macro_info) => self.compile_elements(macro_info.qiita),
+            Element::LinkCard { card_type: _ , url } => {
+                let url = if url.starts_with("/images") {
+                    image_path_github(url.as_str())
+                } else {
+                    url
+                };
+                format!("\n{}\n", url)
+            }
             Element::Image { alt, url } => {
                 let url = if url.starts_with("/images") {
                     image_path_github(url.as_str())
@@ -262,8 +270,11 @@ impl ZennCompiler {
     fn compile_element(&mut self, element: Element) -> String {
         match element {
             Element::Text(text) => text,
-            Element::Url(url) => format!("\n{}\n", url),
+            Element::Url(url) => format!("{}", url),
             Element::Macro(macro_info) => self.compile_elements(macro_info.zenn),
+            Element::LinkCard { card_type, url } => {
+                format!("@[{}]({})", card_type, url)
+            }
             Element::Image { alt, url } => {
                 format!("![{}]({})", alt, url)
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -192,6 +192,7 @@ impl Parser {
             TokenType::Text(text) => Element::Text(text),
             TokenType::Url(url) => Element::Url(url),
             TokenType::Image { alt, url } => Element::Image { alt, url },
+            TokenType::LinkCard { card_type, url } => Element::LinkCard { card_type, url },
             TokenType::InlineFootnote(footnote) => Element::InlineFootnote(footnote),
             TokenType::Footnote(footnote) => Element::Footnote(footnote),
             TokenType::MessageBegin { level, r#type } => {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -158,6 +158,31 @@ impl Scanner {
                     .push(self.make_token(TokenType::Image { alt, url }));
             }
 
+            '@' => {
+                if !self.matches_keyword("@[") {
+                    self.advance();
+                    return Ok(());
+                }
+                self.collect_text();
+                self.expect_string("@[");
+                self.delete_buffer();
+
+                self.extract_until("]")?;
+
+                let card_type = self.consume_buffer();
+                self.expect_string("](");
+                self.delete_buffer();
+
+                self.extract_until(")")?;
+
+                let url = self.consume_buffer();
+                self.expect_string(")");
+                self.delete_buffer();
+
+                self.tokens
+                    .push(self.make_token(TokenType::LinkCard { card_type, url }));
+            }
+
             '^' => {
                 if !self.matches_keyword("^[") {
                     self.advance();

--- a/src/token.rs
+++ b/src/token.rs
@@ -13,6 +13,11 @@ pub enum TokenType {
     Text(String),
     /// http:// or https://
     Url(String),
+    ///LinkCard
+    LinkCard {
+        card_type: String,
+        url: String,
+    },
     /// image
     Image {
         alt: String,


### PR DESCRIPTION
```
@[card](url)
@[gist](url)
```
Zennのリンクカード記法でタイプをgistなどを指定することで埋め込み表示が行われます。
Zennではzenn記法がベースになっているので、そのまま表示し、Qiitaでは上下に改行を含めたURLのみを表示します。

またZennのURL出力に上下改行が含まれていましたが、Zennベース記法が基準だと思うので、それらは取り除きました。
