### PR TITLE
buildターゲット名でファイル名の指定を受け入れる。

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::{
     fs::{self, DirBuilder},
     io::Write,
     process::Command,
+    path::PathBuf,
 };
 
 use crate::print::zeta_message;
@@ -153,6 +154,7 @@ fn new(target: &str, only: &Option<Platform>) {
 }
 
 fn build(target: &str) {
+    let target = &PathBuf::from(target).file_stem().unwrap().to_os_string().into_string().unwrap();
     let Ok(file) = fs::read_to_string(format!("zeta/{}.md", target)) else {
         zeta_error("Target not found");
         return;


### PR DESCRIPTION
タブ補完でzetaフォルダのファイル名をターゲットに指定しても、ターゲット名を適切に変換して実行する。 （拡張子なしのファイル名を取り出す）

具体的には、次のコマンドを、同じ指示とみなす。
zeta build zeta/target_filename.md
zeta build target_filename