### PR TITLE
added qiita_id testing

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -27,6 +27,7 @@ pub struct ZetaFrontmatter {
     pub emoji: String,
     pub r#type: String,
     pub topics: Vec<String>,
+    pub qiita_id: Option<String>,
     pub published: bool,
     /// compile only specified platform
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -58,9 +58,9 @@ impl QiitaCompiler {
                 tags: frontmatter.topics,
                 private: existing_fm.private,
                 updated_at: existing_fm.updated_at.clone(),
-                id: if ! existing_fm.id.is_none() && existing_fm.id.clone().unwrap().len() > 1 {
+                id: if existing_fm.id.is_some() && !existing_fm.id.as_ref().unwrap().is_empty() {
                         existing_fm.id.clone()
-                    } else if ! frontmatter.qiita_id.is_none() && frontmatter.qiita_id.clone().unwrap().len() > 1 {
+                    } else if frontmatter.qiita_id.is_some() && !frontmatter.qiita_id.as_ref().unwrap().is_empty() {
                         frontmatter.qiita_id
                     } else {
                         Some("".to_string())
@@ -75,7 +75,7 @@ impl QiitaCompiler {
                 tags: frontmatter.topics,
                 private: false,
                 updated_at: "".to_string(),
-                id: if ! frontmatter.qiita_id.is_none() { frontmatter.qiita_id } else { Some("".to_string()) },
+                id: if frontmatter.qiita_id.is_some() { frontmatter.qiita_id } else { Some("".to_string()) },
                 organization_url_name: None,
                 slide: false,
                 ignorePublish: !frontmatter.published,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -58,7 +58,13 @@ impl QiitaCompiler {
                 tags: frontmatter.topics,
                 private: existing_fm.private,
                 updated_at: existing_fm.updated_at.clone(),
-                id: existing_fm.id.clone(),
+                id: if ! existing_fm.id.is_none() && existing_fm.id.clone().unwrap().len() > 1 {
+                        existing_fm.id.clone()
+                    } else if ! frontmatter.qiita_id.is_none() && frontmatter.qiita_id.clone().unwrap().len() > 1 {
+                        frontmatter.qiita_id
+                    } else {
+                        Some("".to_string())
+                    },
                 organization_url_name: existing_fm.organization_url_name.clone(),
                 slide: existing_fm.slide,
                 ignorePublish: !frontmatter.published,
@@ -69,7 +75,7 @@ impl QiitaCompiler {
                 tags: frontmatter.topics,
                 private: false,
                 updated_at: "".to_string(),
-                id: None,
+                id: if ! frontmatter.qiita_id.is_none() { frontmatter.qiita_id } else { Some("".to_string()) },
                 organization_url_name: None,
                 slide: false,
                 ignorePublish: !frontmatter.published,

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,7 @@ fn new(target: &str, only: &Option<Platform>) {
         emoji: "😀".to_string(),
         r#type: "tech".to_string(),
         topics: vec![],
+        qiita_id: Some("".to_string()),
         published: false,
         only: only.clone(),
     };

--- a/src/zeta_templete.txt
+++ b/src/zeta_templete.txt
@@ -3,5 +3,6 @@ title: ""
 emoji: "👌"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: []
+qiita_id: 
 published: false
 ---


### PR DESCRIPTION
zetaのIDとQiitaのIDが一致しないケースへの対応。
publicフォルダ下のQiita向けのMarkDownに設定されているIDをzetaフォルダのMarkdownにqiita_idとして設定しておくことで、 build時のQiita向けMarkdown生成時に、qiita_idをIDとして使用する。